### PR TITLE
Upgrade Nebula carina to work with new versions of pydantic and Fastapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ nebula_servers='["192.168.1.10:9669"]'
 nebula_user_name=root
 nebula_password=1234
 nebula_max_connection_pool_size=10
-nebula_carina_paths='["example.models"]'
+nebula_model_paths='["example.models"]'
 nebula_default_space=main
 nebula_auto_create_default_space_with_vid_desc=FIXED_STRING(20)
 nebula_timezone_name=UTC
@@ -68,7 +68,7 @@ nebula_timezone_name=UTC
 
 You can export by:
 ```
-export nebula_carina_paths='["example.models"]' nebula_password=1234 nebula_servers='["192.168.1.10:9669"]' nebula_user_name=root nebula_default_space=main nebula_auto_create_default_space_with_vid_desc=FIXED_STRING(20)
+export nebula_model_paths='["example.models"]' nebula_password=1234 nebula_servers='["192.168.1.10:9669"]' nebula_user_name=root nebula_default_space=main nebula_auto_create_default_space_with_vid_desc=FIXED_STRING(20)
 ```
 
 ## Example
@@ -84,7 +84,7 @@ if main_space_name not in show_spaces():
 Or you can just set `nebula_auto_create_default_space_with_vid_desc=FIXED_STRING(20)` so that it will be automatically handled.
 
 ### Define Models
-Then, develop models defined in nebula_carina_paths.
+Then, develop models defined in nebula_model_paths.
 
 #### Schema Models
 * An TagModel is used to define a nebula tag.

--- a/nebula_carina/models/fields.py
+++ b/nebula_carina/models/fields.py
@@ -1,6 +1,6 @@
 from typing import Union, Any, Optional, TYPE_CHECKING, Type
 
-from pydantic.fields import Undefined, FieldInfo
+from pydantic.fields import FieldInfo
 from pydantic.typing import NoArgAnyCallable
 from nebula_carina.ngql.schema.data_types import DataType, FixedString
 from nebula_carina.ngql.statements.schema import SchemaField
@@ -16,7 +16,7 @@ class NebulaFieldInfo(FieldInfo):
     """
     __slots__ = ('data_type', )
 
-    def __init__(self, data_type: Union[DataType, Type[DataType]], default: Any = Undefined, **kwargs: Any) -> None:
+    def __init__(self, data_type: Union[DataType, Type[DataType]], default: Any = None, **kwargs: Any) -> None:
         super().__init__(default, **kwargs)
         self.data_type = data_type if isinstance(data_type, DataType) else data_type()
 
@@ -29,7 +29,7 @@ class NebulaFieldInfo(FieldInfo):
 
 def create_nebula_field(
         data_type: Union[DataType, Type[DataType]],
-        default: Any = Undefined,
+        default: Any = None,
         *,
         default_factory: Optional[NoArgAnyCallable] = None,
         alias: str = None,

--- a/nebula_carina/models/fields.py
+++ b/nebula_carina/models/fields.py
@@ -1,7 +1,7 @@
 from typing import Union, Any, Optional, TYPE_CHECKING, Type
 
-from pydantic.fields import FieldInfo
-from pydantic.typing import NoArgAnyCallable
+from pydantic.v1.fields import FieldInfo
+from pydantic.v1.typing import NoArgAnyCallable
 from nebula_carina.ngql.schema.data_types import DataType, FixedString
 from nebula_carina.ngql.statements.schema import SchemaField
 

--- a/nebula_carina/models/models.py
+++ b/nebula_carina/models/models.py
@@ -64,7 +64,7 @@ class NebulaSchemaModel(BaseModel, metaclass=NebulaSchemaModelMetaClass):
     @classmethod
     def _create_db_fields(cls):
         return [
-            field_info.create_db_field(field_name)
+            field_info.default.create_db_field(field_name)
             for field_name, field_info in cls.model_fields.items()
             if isinstance(field_info.default, NebulaFieldInfo)
         ]

--- a/nebula_carina/models/models.py
+++ b/nebula_carina/models/models.py
@@ -46,24 +46,24 @@ class NebulaSchemaModel(BaseModel, metaclass=NebulaSchemaModelMetaClass):
     @classmethod
     def _create_db_fields(cls):
         return [
-            field.field_info.create_db_field(field_name) for field_name, field in cls.__fields__.items()
+            field.field_info.create_db_field(field_name) for field_name, field in cls.model_fields.items()
             if isinstance(field.field_info, NebulaFieldInfo)
         ]
 
     @classmethod
     def get_db_field_names(cls) -> list[str]:
         return [
-            field_name for field_name, field in cls.__fields__.items() if isinstance(field.field_info, NebulaFieldInfo)
+            field_name for field_name, field in cls.model_fields.items() if isinstance(field.field_info, NebulaFieldInfo)
         ]
 
     def get_db_field_dict(self) -> dict[str, any]:
         return {
             field_name: field.field_info.data_type.value2db_str(getattr(self, field_name))
-            for field_name, field in self.__class__.__fields__.items() if isinstance(field.field_info, NebulaFieldInfo)
+            for field_name, field in self.__class__.model_fields.items() if isinstance(field.field_info, NebulaFieldInfo)
         }
 
     def get_db_field_value(self, field_name) -> str:
-        return self.__class__.__fields__[field_name].field_info.data_type.value2db_str(getattr(self, field_name))
+        return self.__class__.model_fields[field_name].field_info.data_type.value2db_str(getattr(self, field_name))
 
     @classmethod
     def db_name(cls):
@@ -188,7 +188,7 @@ class VertexModel(NebulaRecordModel):
         """
         return the iterator of tuple[name, tag model] of this class
         """
-        for name, field in cls.__fields__.items():
+        for name, field in cls.model_fields.items():
             if isinstance(field, ModelField) and isclass(field.type_) and issubclass(field.type_, TagModel):
                 yield name, field.type_, field.required
 
@@ -237,7 +237,7 @@ class VertexModel(NebulaRecordModel):
         )
 
     def _get_tag_models(self):
-        for name, field in self.__class__.__fields__.items():
+        for name, field in self.__class__.model_fields.items():
             if isinstance(field, ModelField) and isclass(field.type_) and issubclass(field.type_, TagModel) \
                     and getattr(self, name, None):
                 yield name, field.type_
@@ -307,7 +307,7 @@ class EdgeModel(NebulaRecordModel):
     src_vid: StrictInt | StrictStr
     dst_vid: StrictInt | StrictStr
     ranking: int = 0
-    edge_type_name: str | None  # for view only
+    edge_type_name: str | None = None  # for view only
     edge_type: EdgeTypeModel  # only one edge type
     objects = BaseEdgeManager()
 

--- a/nebula_carina/settings.py
+++ b/nebula_carina/settings.py
@@ -1,6 +1,6 @@
 from typing import Set, Optional, Union
 import typing
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 try:
@@ -8,43 +8,45 @@ try:
     from django.conf import settings
 
     class DjangoCarinaDatabaseSettings(object):
-
         max_connection_pool_size: int = 10
         servers: Set[str] = set()
         user_name: str
         password: str
-        default_space: str = 'main'
+        default_space: str = "main"
         auto_create_default_space_with_vid_desc: Optional[str]
 
         model_paths: Set[str] = set()
-        timezone_name: str = 'UTC'
+        timezone_name: str = "UTC"
 
         @staticmethod
         def is_optional(tp):
             return typing.get_origin(tp) is Union and type(None) in typing.get_args(tp)
 
         def __init__(self, **kwargs):
-            for key, type_ in DjangoCarinaDatabaseSettings.__dict__['__annotations__'].items():
-                if not self.is_optional(type_) and not hasattr(DjangoCarinaDatabaseSettings, key):
-                    assert key in kwargs, f'Setting {key} is required but not provided in CARINA_SETTINGS.'
+            for key, type_ in DjangoCarinaDatabaseSettings.__dict__[
+                "__annotations__"
+            ].items():
+                if not self.is_optional(type_) and not hasattr(
+                    DjangoCarinaDatabaseSettings, key
+                ):
+                    assert (
+                        key in kwargs
+                    ), f"Setting {key} is required but not provided in CARINA_SETTINGS."
                 key in kwargs and setattr(self, key, kwargs[key])
 
     database_settings = DjangoCarinaDatabaseSettings(**settings.CARINA_SETTINGS)
 except ModuleNotFoundError:
-    class DatabaseSettings(BaseSettings):
 
+    class DatabaseSettings(BaseSettings):
         max_connection_pool_size: int = 10
         servers: Set[str] = set()
         user_name: str
         password: str
-        default_space: str = 'main'
+        default_space: str = "main"
         auto_create_default_space_with_vid_desc: Optional[str]
 
         model_paths: Set[str] = set()
-        timezone_name: str = 'UTC'
-
-        class Config:
-            env_prefix = 'nebula_'
-
+        timezone_name: str = "UTC"
+        model_config = SettingsConfigDict(env_prefix="nebula_")
 
     database_settings = DatabaseSettings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-fastapi==0.78.0
+fastapi==0.112.2
 nebula3-python==3.1.0
+pydantic-settings==2.5.2


### PR DESCRIPTION
This is a suggestion to get it to work with Pydantic v2 and fastapi (which uses v2) 

Biggest changes here is moving over to `pydantic_settings` for settings and the accesing of metadata fields.


`__fields__` is deprecated, so ive mostly changed to the new usage in `model_fields`
~~The ones ive kept out, I dont immidiatly know the reasoning for the instance check so I would love some other pair of eyes that know NebulaGraph better to look at.~~   The deprecated `__fields__` just return `model_fields`

Ive been working with it now a bit and it seems to be with `.default` we access the proper field. Ive updated the PR

Ive also added a comment linking to a discussion on the ModelMetadataClass, and why we shouldnt be using that.

So a workaround now is using the internal class, and refactor it later.




I would love for it to be resolved that we can upgrade pydantic here. SInce this package is currently unusable as is.
We are starting an exciting project with NebulaGraph and pydantic and it would be extremly helpful to not have to make a full pydantic to nebulagraph ORM ourselves. 

Thanks for taking the time to address my PR =) 