### PR TITLE
Remove last bit of Pydantic v1

### DIFF
--- a/nebula_carina/models/fields.py
+++ b/nebula_carina/models/fields.py
@@ -26,10 +26,6 @@ class NebulaFieldInfo(FieldInfo):
             field_name, self.data_type, nullable=self.default is None,
             default=self.default if self.default is not Ellipsis else None, comment=self.description
         )
-    # Port usage from pydantic v1 temporary
-    def _validate(self) -> None:
-        if self.default is not PydanticUndefined and self.default_factory is not None:
-            raise ValueError('cannot specify both default and default_factory')
 
 
 def create_nebula_field(
@@ -91,5 +87,4 @@ def create_nebula_field(
         repr=repr,
         **extra,
     )
-    field_info._validate()
     return field_info

--- a/nebula_carina/models/fields.py
+++ b/nebula_carina/models/fields.py
@@ -1,7 +1,7 @@
-from typing import Union, Any, Optional, TYPE_CHECKING, Type
+from typing import Union, Any, Optional, TYPE_CHECKING, Type, Callable
 
-from pydantic.v1.fields import FieldInfo
-from pydantic.v1.typing import NoArgAnyCallable
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 from nebula_carina.ngql.schema.data_types import DataType, FixedString
 from nebula_carina.ngql.statements.schema import SchemaField
 
@@ -9,6 +9,7 @@ from nebula_carina.ngql.statements.schema import SchemaField
 if TYPE_CHECKING:
     from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
 
+NoArgAnyCallable = Callable[[], Any]
 
 class NebulaFieldInfo(FieldInfo):
     """
@@ -16,8 +17,8 @@ class NebulaFieldInfo(FieldInfo):
     """
     __slots__ = ('data_type', )
 
-    def __init__(self, data_type: Union[DataType, Type[DataType]], default: Any = None, **kwargs: Any) -> None:
-        super().__init__(default, **kwargs)
+    def __init__(self, data_type: Union[DataType, Type[DataType]],  **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         self.data_type = data_type if isinstance(data_type, DataType) else data_type()
 
     def create_db_field(self, field_name) -> SchemaField:
@@ -25,6 +26,10 @@ class NebulaFieldInfo(FieldInfo):
             field_name, self.data_type, nullable=self.default is None,
             default=self.default if self.default is not Ellipsis else None, comment=self.description
         )
+    # Port usage from pydantic v1 temporary
+    def _validate(self) -> None:
+        if self.default is not PydanticUndefined and self.default_factory is not None:
+            raise ValueError('cannot specify both default and default_factory')
 
 
 def create_nebula_field(
@@ -60,7 +65,7 @@ def create_nebula_field(
         max_length = data_type.max_length
     field_info = NebulaFieldInfo(
         data_type,
-        default,
+        default=default,
         default_factory=default_factory,
         alias=alias,
         title=title,


### PR DESCRIPTION
After moving to FieldInfo from v2, we can access the NebulaField ina. regular way again  =) 


Also went through more of the code and removed references to v1 of pydantic. 


I believe with the accesing of `.model_field` we now have the same access.

I also removed the `ModelField`check since that will never happen with new pydantic. 

Checking the annotation should suffice. 

Please let me know if there are any more cases I havent thought of.


I will when I get slightly more time, clean up more. And maybe I can move over to using PDM.
Depends on time