### PR TITLE
Fix annotation access for Python 3.14 compatibility

### DIFF
--- a/nebula_carina/settings.py
+++ b/nebula_carina/settings.py
@@ -23,9 +23,8 @@ try:
             return typing.get_origin(tp) is Union and type(None) in typing.get_args(tp)
 
         def __init__(self, **kwargs):
-            for key, type_ in DjangoCarinaDatabaseSettings.__dict__[
-                "__annotations__"
-            ].items():
+            annotations = getattr(DjangoCarinaDatabaseSettings, "__annotations__", {})
+            for key, type_ in annotations.items():
                 if not self.is_optional(type_) and not hasattr(
                     DjangoCarinaDatabaseSettings, key
                 ):


### PR DESCRIPTION
Description:
Update annotation access to maintain compatibility with Python 3.14's deferred annotation evaluation (PEP 649 & PEP 749).

In Python 3.14, annotations are no longer eagerly evaluated and stored directly in __annotations__. Instead, they're deferred and accessed through special mechanisms. This change caused our previous direct dictionary access to fail with a KeyError.

The fix replaces direct __dict__["__annotations__"] access with getattr(..., "__annotations__", {}) which safely handles both:

Pre-3.14 versions where annotations are stored directly in __annotations__ Python 3.14+ where annotations use deferred evaluation This ensures consistent behavior across Python versions while leveraging the new annotation system's benefits in 3.14+.